### PR TITLE
fix: correct bundle generation

### DIFF
--- a/bundle.Dockerfile.model-validation.rh
+++ b/bundle.Dockerfile.model-validation.rh
@@ -1,6 +1,7 @@
 ARG VERSION="0.0.1"
 ARG CHANNELS="tech-preview"
 ARG DEFAULT_CHANNEL="tech-preview"
+ARG BUNDLE_OVERLAY="olm"
 ARG BUNDLE_GEN_FLAGS="-q --overwrite=false --version $VERSION --channels=$CHANNELS --default-channel=$DEFAULT_CHANNEL"
 ARG IMG
 
@@ -8,6 +9,7 @@ FROM registry.redhat.io/openshift4/ose-operator-sdk-rhel9@sha256:c466d80c1eab6eb
 
 ARG BUNDLE_GEN_FLAGS
 ARG IMG
+ARG BUNDLE_OVERLAY
 
 WORKDIR /tmp
 

--- a/hack/build-bundle.sh
+++ b/hack/build-bundle.sh
@@ -29,7 +29,8 @@ CSV="bundle/manifests/model-validation-operator.clusterserviceversion.yaml"
 if [[ -f "${CSV}" ]]; then
   sed -i.bak  's/deploymentName: webhook/deploymentName: model-validation-controller-manager/' "${CSV}"
   sed -i.bak2 's/deploymentName: model-validation-controller-manager/deploymentName: model-validation-controller-manager\
-    serviceName: model-validation-webhook/' "${CSV}"
+    serviceName: model-validation-webhook\
+    containerPort: 9443/' "${CSV}"
   rm -f "${CSV}.bak" "${CSV}.bak2"
 fi
 

--- a/hack/build-bundle.sh
+++ b/hack/build-bundle.sh
@@ -1,27 +1,36 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 TOOLS="/tmp"
 
-if [ -d "/cachi2" ]
-then
-  tar -xzf /cachi2/output/deps/generic/kustomize_v5.6.0_linux_amd64.tar.gz -C ${TOOLS}
-  KUSTOMIZE=${TOOLS}/kustomize
+if [ -d "/cachi2" ]; then
+  tar -xzf /cachi2/output/deps/generic/kustomize_v5.6.0_linux_amd64.tar.gz -C "${TOOLS}"
+  KUSTOMIZE="${TOOLS}/kustomize"
 else
-  curl -Lo ${TOOLS}/kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.6.0/kustomize_v5.6.0_linux_amd64.tar.gz" && \
-  tar -xzf ${TOOLS}/kustomize.tar.gz -C ${TOOLS}
-  rm ${TOOLS}/kustomize.tar.gz
-  KUSTOMIZE=${TOOLS}/kustomize
+  curl -Lo "${TOOLS}/kustomize.tar.gz" "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.6.0/kustomize_v5.6.0_linux_amd64.tar.gz"
+  tar -xzf "${TOOLS}/kustomize.tar.gz" -C "${TOOLS}"
+  rm "${TOOLS}/kustomize.tar.gz"
+  KUSTOMIZE="${TOOLS}/kustomize"
 fi
-chmod +x ${KUSTOMIZE}
+chmod +x "${KUSTOMIZE}"
 
-if [[ -n "$IMG" ]]
-then
-  pushd config/manager
-  ${KUSTOMIZE} edit set image controller="${IMG}"
-  popd
+operator-sdk generate kustomize manifests -q
+
+if [[ -n "${IMG:-}" ]]; then
+  pushd "config/overlays/${BUNDLE_OVERLAY}" >/dev/null
+  "${KUSTOMIZE}" edit set image "controller=${IMG}"
+  popd >/dev/null
 fi
 
-${KUSTOMIZE} build config/manifests | operator-sdk generate bundle ${BUNDLE_GEN_FLAGS}
+"${KUSTOMIZE}" build "config/overlays/${BUNDLE_OVERLAY}" \
+  | operator-sdk generate bundle ${BUNDLE_GEN_FLAGS}
+
+CSV="bundle/manifests/model-validation-operator.clusterserviceversion.yaml"
+if [[ -f "${CSV}" ]]; then
+  sed -i.bak  's/deploymentName: webhook/deploymentName: model-validation-controller-manager/' "${CSV}"
+  sed -i.bak2 's/deploymentName: model-validation-controller-manager/deploymentName: model-validation-controller-manager\
+    serviceName: model-validation-webhook/' "${CSV}"
+  rm -f "${CSV}.bak" "${CSV}.bak2"
+fi
 
 operator-sdk bundle validate ./bundle


### PR DESCRIPTION
## Summary by Sourcery

Refine build-bundle.sh to improve robustness, enable dynamic overlay support, and correct generated CSV metadata.

Bug Fixes:
- Fix incorrect deploymentName references in the generated CSV and ensure the webhook serviceName is properly injected

Enhancements:
- Switch to a portable bash shebang with strict error handling (set -euo pipefail) and consistent variable quoting
- Invoke "operator-sdk generate kustomize manifests" before applying overlay edits
- Use a configurable bundle overlay path for Kustomize build
- Automate post-processing of the generated CSV to patch deployment and service names