### PR TITLE
Add NetworkPolicy controller to restrict operator pod traffic

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -58,11 +58,16 @@ jobs:
       AGENT_IMG: ghcr.io/securesign/model-validation-operator-agent:dev-${{ github.sha }}
       BUNDLE_IMG: ghcr.io/securesign/model-validation-operator-bundle:dev-${{ github.sha }}
       CATALOG_IMG: ghcr.io/securesign/model-validation-operator-fbc:dev-${{ github.sha }}
-      OLM_UPGRADE_VERSION: 0.1.2
       OCP_VERSION: ${{ vars.OLM_INDEX_VERSION }}
     steps:
       - name: Checkout source
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
+
+      - name: Compute OLM upgrade version
+        run: |
+          CURRENT=$(grep '^VERSION ?=' Makefile | cut -d= -f2 | tr -d ' ')
+          NEXT=$(echo "$CURRENT" | awk -F. '{print $1"."$2"."$3+1}')
+          echo "OLM_UPGRADE_VERSION=$NEXT" >> "$GITHUB_ENV"
 
       - name: Setup Go
         uses: actions/setup-go@def8c394e3ad351a79bc93815e4a585520fe993b # v5

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,8 +18,10 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sigstore/model-validation-operator/internal/constants"
@@ -318,9 +320,38 @@ func main() {
 		os.Exit(1)
 	}
 
+	operatorNamespace := getOperatorNamespace()
+	if operatorNamespace == "" {
+		setupLog.Error(fmt.Errorf("operator namespace not found"), "set POD_NAMESPACE env var or run in-cluster")
+		os.Exit(1)
+	}
+
+	npReconciler := &controller.NetworkPolicyReconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Namespace: operatorNamespace,
+	}
+	if err := npReconciler.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create NetworkPolicy controller")
+		os.Exit(1)
+	}
+
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+const namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+func getOperatorNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+	data, err := os.ReadFile(namespaceFile)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -322,18 +321,17 @@ func main() {
 
 	operatorNamespace := getOperatorNamespace()
 	if operatorNamespace == "" {
-		setupLog.Error(fmt.Errorf("operator namespace not found"), "set POD_NAMESPACE env var or run in-cluster")
-		os.Exit(1)
-	}
-
-	npReconciler := &controller.NetworkPolicyReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Namespace: operatorNamespace,
-	}
-	if err := npReconciler.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create NetworkPolicy controller")
-		os.Exit(1)
+		setupLog.Info("operator namespace not found, skipping NetworkPolicy controller (set POD_NAMESPACE for local runs)")
+	} else {
+		npReconciler := &controller.NetworkPolicyReconciler{
+			Client:    mgr.GetClient(),
+			Scheme:    mgr.GetScheme(),
+			Namespace: operatorNamespace,
+		}
+		if err := npReconciler.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create NetworkPolicy controller")
+			os.Exit(1)
+		}
 	}
 
 	setupLog.Info("starting manager")

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,11 @@ spec:
           - --health-probe-bind-address=:8081
         image: controller:latest
         name: manager
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,3 +41,14 @@ rules:
   - modelvalidations/status
   verbs:
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/controller/networkpolicy_controller.go
+++ b/internal/controller/networkpolicy_controller.go
@@ -82,17 +82,9 @@ func (r *NetworkPolicyReconciler) desiredSpec() networkingv1.NetworkPolicySpec {
 			networkingv1.PolicyTypeEgress,
 		},
 		Ingress: []networkingv1.NetworkPolicyIngressRule{
-			// Webhook: only the API server (represented via the default namespace) calls this.
+			// Webhook: the kube-apiserver runs on the host network, so no
+			// pod/namespace selector can match it — restrict by port only.
 			{
-				From: []networkingv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": "default",
-							},
-						},
-					},
-				},
 				Ports: []networkingv1.NetworkPolicyPort{
 					{Port: &port9443, Protocol: &protocolTCP},
 				},
@@ -152,17 +144,9 @@ func (r *NetworkPolicyReconciler) desiredSpec() networkingv1.NetworkPolicySpec {
 					{Port: &port53, Protocol: &protocolUDP},
 				},
 			},
-			// Kubernetes API server.
+			// Kubernetes API server: the apiserver uses host networking, so
+			// namespace selectors cannot match the destination — restrict by port only.
 			{
-				To: []networkingv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": "default",
-							},
-						},
-					},
-				},
 				Ports: []networkingv1.NetworkPolicyPort{
 					{Port: &port443, Protocol: &protocolTCP},
 					{Port: &port6443, Protocol: &protocolTCP},

--- a/internal/controller/networkpolicy_controller.go
+++ b/internal/controller/networkpolicy_controller.go
@@ -1,0 +1,135 @@
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const networkPolicyName = "controller-manager"
+
+// NetworkPolicyReconciler ensures a static NetworkPolicy exists in the operator namespace,
+// restricting traffic to only the required endpoints.
+type NetworkPolicyReconciler struct {
+	client.Client
+	Scheme    *runtime.Scheme
+	Namespace string
+}
+
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch
+
+// Reconcile ensures the operator's NetworkPolicy exists with the desired spec
+func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyName,
+			Namespace: r.Namespace,
+		},
+	}
+
+	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, np, func() error {
+		np.Labels = map[string]string{
+			"app.kubernetes.io/name":       "model-validation-operator",
+			"app.kubernetes.io/managed-by": "model-validation-operator",
+		}
+		np.Spec = r.desiredSpec()
+		return nil
+	})
+	if err != nil {
+		logger.Error(err, "Failed to reconcile NetworkPolicy")
+		return ctrl.Result{}, err
+	}
+
+	if result != controllerutil.OperationResultNone {
+		logger.Info("NetworkPolicy reconciled", "operation", result)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *NetworkPolicyReconciler) desiredSpec() networkingv1.NetworkPolicySpec {
+	port53 := intstr.FromInt32(53)
+	port443 := intstr.FromInt32(443)
+	port6443 := intstr.FromInt32(6443)
+	port8081 := intstr.FromInt32(8081)
+	port9443 := intstr.FromInt32(9443)
+	protocolTCP := corev1.ProtocolTCP
+	protocolUDP := corev1.ProtocolUDP
+
+	return networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"control-plane":          "controller-manager",
+				"app.kubernetes.io/name": "model-validation-operator",
+			},
+		},
+		PolicyTypes: []networkingv1.PolicyType{
+			networkingv1.PolicyTypeIngress,
+			networkingv1.PolicyTypeEgress,
+		},
+		Ingress: []networkingv1.NetworkPolicyIngressRule{
+			{
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &port9443, Protocol: &protocolTCP},
+					{Port: &port8081, Protocol: &protocolTCP},
+				},
+			},
+		},
+		Egress: []networkingv1.NetworkPolicyEgressRule{
+			{
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &port53, Protocol: &protocolTCP},
+					{Port: &port53, Protocol: &protocolUDP},
+				},
+			},
+			{
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &port443, Protocol: &protocolTCP},
+					{Port: &port6443, Protocol: &protocolTCP},
+				},
+			},
+		},
+	}
+}
+
+// SetupWithManager sets up the controller with the Manager
+func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	isOurNetworkPolicy := func(_ context.Context, obj client.Object) []reconcile.Request {
+		if obj.GetName() == networkPolicyName && obj.GetNamespace() == r.Namespace {
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{
+				Name:      networkPolicyName,
+				Namespace: r.Namespace,
+			}}}
+		}
+		return nil
+	}
+
+	isOurNamespace := func(_ context.Context, obj client.Object) []reconcile.Request {
+		if obj.GetName() == r.Namespace {
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{
+				Name:      networkPolicyName,
+				Namespace: r.Namespace,
+			}}}
+		}
+		return nil
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("networkpolicy").
+		Watches(&networkingv1.NetworkPolicy{}, handler.EnqueueRequestsFromMapFunc(isOurNetworkPolicy)).
+		Watches(&corev1.Namespace{}, handler.EnqueueRequestsFromMapFunc(isOurNamespace)).
+		Complete(r)
+}

--- a/internal/controller/networkpolicy_controller.go
+++ b/internal/controller/networkpolicy_controller.go
@@ -65,6 +65,7 @@ func (r *NetworkPolicyReconciler) desiredSpec() networkingv1.NetworkPolicySpec {
 	port443 := intstr.FromInt32(443)
 	port6443 := intstr.FromInt32(6443)
 	port8081 := intstr.FromInt32(8081)
+	port8443 := intstr.FromInt32(8443)
 	port9443 := intstr.FromInt32(9443)
 	protocolTCP := corev1.ProtocolTCP
 	protocolUDP := corev1.ProtocolUDP
@@ -81,21 +82,84 @@ func (r *NetworkPolicyReconciler) desiredSpec() networkingv1.NetworkPolicySpec {
 			networkingv1.PolicyTypeEgress,
 		},
 		Ingress: []networkingv1.NetworkPolicyIngressRule{
+			// Webhook: only the API server (represented via the default namespace) calls this.
 			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "default",
+							},
+						},
+					},
+				},
 				Ports: []networkingv1.NetworkPolicyPort{
 					{Port: &port9443, Protocol: &protocolTCP},
+				},
+			},
+			// Health probes: kubelet traffic is not subject to NetworkPolicy, but
+			// in-cluster liveness checks (e.g. from the same namespace) need access.
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
 					{Port: &port8081, Protocol: &protocolTCP},
+				},
+			},
+			// Metrics: scoped to namespaces labeled metrics=enabled.
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"metrics": "enabled",
+							},
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &port8443, Protocol: &protocolTCP},
 				},
 			},
 		},
 		Egress: []networkingv1.NetworkPolicyEgressRule{
+			// DNS: scoped to kube-system (vanilla K8s) and openshift-dns (OpenShift).
 			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-system",
+							},
+						},
+					},
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "openshift-dns",
+							},
+						},
+					},
+				},
 				Ports: []networkingv1.NetworkPolicyPort{
 					{Port: &port53, Protocol: &protocolTCP},
 					{Port: &port53, Protocol: &protocolUDP},
 				},
 			},
+			// Kubernetes API server.
 			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "default",
+							},
+						},
+					},
+				},
 				Ports: []networkingv1.NetworkPolicyPort{
 					{Port: &port443, Protocol: &protocolTCP},
 					{Port: &port6443, Protocol: &protocolTCP},

--- a/internal/controller/networkpolicy_controller.go
+++ b/internal/controller/networkpolicy_controller.go
@@ -109,9 +109,12 @@ func (r *NetworkPolicyReconciler) desiredSpec() networkingv1.NetworkPolicySpec {
 					{Port: &port8081, Protocol: &protocolTCP},
 				},
 			},
-			// Metrics: scoped to namespaces labeled metrics=enabled.
+			// Metrics: same-namespace pods and namespaces labeled metrics=enabled.
 			{
 				From: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{},
+					},
 					{
 						NamespaceSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{

--- a/internal/controller/networkpolicy_controller_test.go
+++ b/internal/controller/networkpolicy_controller_test.go
@@ -59,11 +59,8 @@ var _ = Describe("NetworkPolicyReconciler", func() {
 
 			Expect(np.Spec.Ingress).To(HaveLen(3))
 
-			By("webhook ingress scoped to the default namespace")
-			Expect(np.Spec.Ingress[0].From).To(HaveLen(1))
-			Expect(np.Spec.Ingress[0].From[0].NamespaceSelector).NotTo(BeNil())
-			Expect(np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels).To(
-				HaveKeyWithValue("kubernetes.io/metadata.name", "default"))
+			By("webhook ingress restricted by port only (apiserver uses host network)")
+			Expect(np.Spec.Ingress[0].From).To(BeEmpty())
 			expectPort(np.Spec.Ingress[0].Ports, 9443, corev1.ProtocolTCP)
 
 			By("health probe ingress scoped to same-namespace pods")
@@ -88,10 +85,8 @@ var _ = Describe("NetworkPolicyReconciler", func() {
 			expectPort(np.Spec.Egress[0].Ports, 53, corev1.ProtocolTCP)
 			expectPort(np.Spec.Egress[0].Ports, 53, corev1.ProtocolUDP)
 
-			By("API server egress scoped to the default namespace")
-			Expect(np.Spec.Egress[1].To).To(HaveLen(1))
-			Expect(np.Spec.Egress[1].To[0].NamespaceSelector.MatchLabels).To(
-				HaveKeyWithValue("kubernetes.io/metadata.name", "default"))
+			By("API server egress restricted by port only (apiserver uses host network)")
+			Expect(np.Spec.Egress[1].To).To(BeEmpty())
 			expectPort(np.Spec.Egress[1].Ports, 443, corev1.ProtocolTCP)
 			expectPort(np.Spec.Egress[1].Ports, 6443, corev1.ProtocolTCP)
 		})

--- a/internal/controller/networkpolicy_controller_test.go
+++ b/internal/controller/networkpolicy_controller_test.go
@@ -71,10 +71,11 @@ var _ = Describe("NetworkPolicyReconciler", func() {
 			Expect(np.Spec.Ingress[1].From[0].PodSelector).NotTo(BeNil())
 			expectPort(np.Spec.Ingress[1].Ports, 8081, corev1.ProtocolTCP)
 
-			By("metrics ingress scoped to metrics-enabled namespaces")
-			Expect(np.Spec.Ingress[2].From).To(HaveLen(1))
-			Expect(np.Spec.Ingress[2].From[0].NamespaceSelector).NotTo(BeNil())
-			Expect(np.Spec.Ingress[2].From[0].NamespaceSelector.MatchLabels).To(HaveKeyWithValue("metrics", "enabled"))
+			By("metrics ingress scoped to same-namespace pods and metrics-enabled namespaces")
+			Expect(np.Spec.Ingress[2].From).To(HaveLen(2))
+			Expect(np.Spec.Ingress[2].From[0].PodSelector).NotTo(BeNil())
+			Expect(np.Spec.Ingress[2].From[1].NamespaceSelector).NotTo(BeNil())
+			Expect(np.Spec.Ingress[2].From[1].NamespaceSelector.MatchLabels).To(HaveKeyWithValue("metrics", "enabled"))
 			expectPort(np.Spec.Ingress[2].Ports, 8443, corev1.ProtocolTCP)
 
 			By("DNS egress scoped to kube-system and openshift-dns")

--- a/internal/controller/networkpolicy_controller_test.go
+++ b/internal/controller/networkpolicy_controller_test.go
@@ -1,0 +1,185 @@
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/sigstore/model-validation-operator/internal/testutil"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("NetworkPolicyReconciler", func() {
+	var (
+		ctx        context.Context
+		reconciler *NetworkPolicyReconciler
+		namespace  string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "test-operator-ns"
+	})
+
+	Context("when the NetworkPolicy does not exist", func() {
+		It("should create the NetworkPolicy with the correct spec", func() {
+			fakeClient := testutil.SetupFakeClientWithObjects()
+
+			reconciler = &NetworkPolicyReconciler{
+				Client:    fakeClient,
+				Scheme:    runtime.NewScheme(),
+				Namespace: namespace,
+			}
+
+			req := testutil.CreateReconcileRequest(namespace, networkPolicyName)
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			np := &networkingv1.NetworkPolicy{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: namespace}, np)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(np.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "model-validation-operator"))
+			Expect(np.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "model-validation-operator"))
+
+			Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("control-plane", "controller-manager"))
+			Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "model-validation-operator"))
+
+			Expect(np.Spec.PolicyTypes).To(ConsistOf(
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			))
+
+			Expect(np.Spec.Ingress).To(HaveLen(1))
+			expectPort(np.Spec.Ingress[0].Ports, 9443, corev1.ProtocolTCP)
+			expectPort(np.Spec.Ingress[0].Ports, 8081, corev1.ProtocolTCP)
+
+			Expect(np.Spec.Egress).To(HaveLen(2))
+			expectPort(np.Spec.Egress[0].Ports, 53, corev1.ProtocolTCP)
+			expectPort(np.Spec.Egress[0].Ports, 53, corev1.ProtocolUDP)
+			expectPort(np.Spec.Egress[1].Ports, 443, corev1.ProtocolTCP)
+			expectPort(np.Spec.Egress[1].Ports, 6443, corev1.ProtocolTCP)
+		})
+	})
+
+	Context("when the NetworkPolicy already exists with wrong spec", func() {
+		It("should update the NetworkPolicy to the desired spec", func() {
+			existingNP := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      networkPolicyName,
+					Namespace: namespace,
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				},
+			}
+
+			fakeClient := testutil.SetupFakeClientWithObjects(existingNP)
+
+			reconciler = &NetworkPolicyReconciler{
+				Client:    fakeClient,
+				Scheme:    runtime.NewScheme(),
+				Namespace: namespace,
+			}
+
+			req := testutil.CreateReconcileRequest(namespace, networkPolicyName)
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			np := &networkingv1.NetworkPolicy{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: namespace}, np)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(np.Spec.PolicyTypes).To(ConsistOf(
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			))
+			Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("control-plane", "controller-manager"))
+			Expect(np.Spec.Ingress).To(HaveLen(1))
+			Expect(np.Spec.Egress).To(HaveLen(2))
+		})
+	})
+
+	Context("when the NetworkPolicy already has the correct spec", func() {
+		It("should be idempotent and not error", func() {
+			fakeClient := testutil.SetupFakeClientWithObjects()
+
+			reconciler = &NetworkPolicyReconciler{
+				Client:    fakeClient,
+				Scheme:    runtime.NewScheme(),
+				Namespace: namespace,
+			}
+
+			req := testutil.CreateReconcileRequest(namespace, networkPolicyName)
+
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			result, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			np := &networkingv1.NetworkPolicy{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: namespace}, np)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(np.Spec.Ingress).To(HaveLen(1))
+			Expect(np.Spec.Egress).To(HaveLen(2))
+		})
+	})
+
+	Context("when the NetworkPolicy is deleted externally", func() {
+		It("should re-create the NetworkPolicy", func() {
+			fakeClient := testutil.SetupFakeClientWithObjects()
+
+			reconciler = &NetworkPolicyReconciler{
+				Client:    fakeClient,
+				Scheme:    runtime.NewScheme(),
+				Namespace: namespace,
+			}
+
+			req := testutil.CreateReconcileRequest(namespace, networkPolicyName)
+
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			np := &networkingv1.NetworkPolicy{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: namespace}, np)
+			Expect(err).NotTo(HaveOccurred())
+			err = fakeClient.Delete(ctx, np)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: namespace}, np)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(np.Spec.PolicyTypes).To(ConsistOf(
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			))
+		})
+	})
+})
+
+func expectPort(ports []networkingv1.NetworkPolicyPort, portNum int32, protocol corev1.Protocol) {
+	port := intstr.FromInt32(portNum)
+	found := false
+	for _, p := range ports {
+		if p.Port != nil && *p.Port == port && p.Protocol != nil && *p.Protocol == protocol {
+			found = true
+			break
+		}
+	}
+	ExpectWithOffset(1, found).To(BeTrue(), "expected port %d/%s in ports %v", portNum, protocol, ports)
+}

--- a/internal/controller/networkpolicy_controller_test.go
+++ b/internal/controller/networkpolicy_controller_test.go
@@ -57,13 +57,40 @@ var _ = Describe("NetworkPolicyReconciler", func() {
 				networkingv1.PolicyTypeEgress,
 			))
 
-			Expect(np.Spec.Ingress).To(HaveLen(1))
-			expectPort(np.Spec.Ingress[0].Ports, 9443, corev1.ProtocolTCP)
-			expectPort(np.Spec.Ingress[0].Ports, 8081, corev1.ProtocolTCP)
+			Expect(np.Spec.Ingress).To(HaveLen(3))
 
+			By("webhook ingress scoped to the default namespace")
+			Expect(np.Spec.Ingress[0].From).To(HaveLen(1))
+			Expect(np.Spec.Ingress[0].From[0].NamespaceSelector).NotTo(BeNil())
+			Expect(np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels).To(
+				HaveKeyWithValue("kubernetes.io/metadata.name", "default"))
+			expectPort(np.Spec.Ingress[0].Ports, 9443, corev1.ProtocolTCP)
+
+			By("health probe ingress scoped to same-namespace pods")
+			Expect(np.Spec.Ingress[1].From).To(HaveLen(1))
+			Expect(np.Spec.Ingress[1].From[0].PodSelector).NotTo(BeNil())
+			expectPort(np.Spec.Ingress[1].Ports, 8081, corev1.ProtocolTCP)
+
+			By("metrics ingress scoped to metrics-enabled namespaces")
+			Expect(np.Spec.Ingress[2].From).To(HaveLen(1))
+			Expect(np.Spec.Ingress[2].From[0].NamespaceSelector).NotTo(BeNil())
+			Expect(np.Spec.Ingress[2].From[0].NamespaceSelector.MatchLabels).To(HaveKeyWithValue("metrics", "enabled"))
+			expectPort(np.Spec.Ingress[2].Ports, 8443, corev1.ProtocolTCP)
+
+			By("DNS egress scoped to kube-system and openshift-dns")
 			Expect(np.Spec.Egress).To(HaveLen(2))
+			Expect(np.Spec.Egress[0].To).To(HaveLen(2))
+			Expect(np.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels).To(
+				HaveKeyWithValue("kubernetes.io/metadata.name", "kube-system"))
+			Expect(np.Spec.Egress[0].To[1].NamespaceSelector.MatchLabels).To(
+				HaveKeyWithValue("kubernetes.io/metadata.name", "openshift-dns"))
 			expectPort(np.Spec.Egress[0].Ports, 53, corev1.ProtocolTCP)
 			expectPort(np.Spec.Egress[0].Ports, 53, corev1.ProtocolUDP)
+
+			By("API server egress scoped to the default namespace")
+			Expect(np.Spec.Egress[1].To).To(HaveLen(1))
+			Expect(np.Spec.Egress[1].To[0].NamespaceSelector.MatchLabels).To(
+				HaveKeyWithValue("kubernetes.io/metadata.name", "default"))
 			expectPort(np.Spec.Egress[1].Ports, 443, corev1.ProtocolTCP)
 			expectPort(np.Spec.Egress[1].Ports, 6443, corev1.ProtocolTCP)
 		})
@@ -104,7 +131,7 @@ var _ = Describe("NetworkPolicyReconciler", func() {
 				networkingv1.PolicyTypeEgress,
 			))
 			Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("control-plane", "controller-manager"))
-			Expect(np.Spec.Ingress).To(HaveLen(1))
+			Expect(np.Spec.Ingress).To(HaveLen(3))
 			Expect(np.Spec.Egress).To(HaveLen(2))
 		})
 	})
@@ -132,7 +159,7 @@ var _ = Describe("NetworkPolicyReconciler", func() {
 			np := &networkingv1.NetworkPolicy{}
 			err = fakeClient.Get(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: namespace}, np)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(np.Spec.Ingress).To(HaveLen(1))
+			Expect(np.Spec.Ingress).To(HaveLen(3))
 			Expect(np.Spec.Egress).To(HaveLen(2))
 		})
 	})

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sigstore/model-validation-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -185,6 +186,9 @@ func CreateTestNamespacedName(name, namespace string) types.NamespacedName {
 func SetupFakeClientWithObjects(objects ...client.Object) client.Client {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
+		panic(err) // This should not happen in tests
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
 		panic(err) // This should not happen in tests
 	}
 	if err := v1alpha1.AddToScheme(scheme); err != nil {


### PR DESCRIPTION
Introduce a self-healing NetworkPolicy reconciler that enforces ingress (9443, 8081) and egress (DNS, HTTPS, K8s API) rules on the operator pod. The controller watches for drift and recreates or updates the policy automatically. Includes RBAC permissions, POD_NAMESPACE downward API injection, unit tests, and test utility updates for NetworkPolicy scheme.